### PR TITLE
Force LF endings in init-mongo.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Makes sure init-mongo.sh is cloned/pulled with LF endings even on Windows
+# Without this, it issues a "$'\r': command not found" error.
+init-mongo.sh text eol=lf


### PR DESCRIPTION
On windows, git converts LF endings to CRLF endings by default.
This causes the init-mongo.sh script to break when it's copied into the docker container and executed by MongoDB.

To prevent the conversion from LF endings (on the remote) to CRLF endings (on Windows), this PR adds a gitattributes file. It forces LF endings in init-mongo.sh, overriding git's settings.